### PR TITLE
Fixes reset logic, adds support for ActiveSupport::Cache::Store

### DIFF
--- a/lib/rate_limiting.rb
+++ b/lib/rate_limiting.rb
@@ -5,6 +5,7 @@ class RateLimiting
 
   def initialize(app, &block)
     @app = app
+    @logger =  nil
     @rules = []
     @cache = {}
     block.call(self)
@@ -12,6 +13,7 @@ class RateLimiting
 
   def call(env)
     request = Rack::Request.new(env)
+    @logger = env['rack.logger']
     (limit_header = allowed?(request)) ? respond(env, limit_header) : rate_limit_exceeded(env['HTTP_ACCEPT'])
   end
 
@@ -22,9 +24,9 @@ class RateLimiting
 
   def rate_limit_exceeded(accept)
     case accept.gsub(/;.*/, "").split(',')[0]
-    when "text/xml"         then message, type  = xml_error("403", "Rate Limit Exceeded"), "text/xml" 
+    when "text/xml"         then message, type  = xml_error("403", "Rate Limit Exceeded"), "text/xml"
     when "application/json" then  message, type  = ["Rate Limit Exceeded"].to_json, "application/json"
-    else 
+    else
       message, type  = ["Rate Limit Exceeded"], "text/html"
     end
     [403, {"Content-Type" => type}, message]
@@ -46,11 +48,13 @@ class RateLimiting
   end
 
   def cache_has?(key)
-    case 
+    case
     when cache.respond_to?(:has_key?)
       cache.has_key?(key)
     when cache.respond_to?(:get)
       cache.get(key) rescue false
+    when cache.respond_to?(:exist?)
+      cache.exist?(key)
     else false
     end
   end
@@ -61,6 +65,8 @@ class RateLimiting
       return cache[key]
     when cache.respond_to?(:get)
       return cache.get(key) || nil
+    when cache.respond_to?(:fetch)
+      return cache.fetch(key)
     end
   end
 
@@ -74,11 +80,22 @@ class RateLimiting
       end
     when cache.respond_to?(:set)
       cache.set(key, value)
+    when cache.respond_to?(:write)
+      begin
+        cache.write(key, value)
+      rescue TypeError => e
+        cache.write(key, value.to_s)
+      end
     end
+  end
+
+  def logger
+    @logger || Rack::NullLogger.new(nil)
   end
 
   def allowed?(request)
     if rule = find_matching_rule(request)
+      logger.debug "[#{self}] #{request.ip}:#{request.path}: Rate limiting rule matched."
       apply_rule(request, rule)
     else
       true
@@ -96,30 +113,35 @@ class RateLimiting
     key = rule.get_key(request)
     if cache_has?(key)
       record = cache_get(key)
-      if (reset = record.split(':')[1]) > Time.now.strftime("%d%m%y%H%M%S")
-        if (times = record.split(':')[0].to_i) < rule.limit
+      logger.debug "[#{self}] #{request.ip}:#{request.path}: Rate limiting entry: '#{key}' => #{record}"
+      if (reset = Time.at(record.split(':')[1].to_i)) > Time.now
+        # rule hasn't been reset yet
+        times = record.split(':')[0].to_i
+        cache_set(key, "#{times + 1}:#{reset.to_i}")
+        if (times) < rule.limit
+          # within rate limit
           response = get_header(times + 1, reset, rule.limit)
-          record = record.gsub(/.*:/, "#{times + 1}:")
         else
+          logger.debug "[#{self}] #{request.ip}:#{request.path}: Rate limited; request rejected."
           return false
         end
       else
-        response = get_header(1, reset = rule.get_expiration, rule.limit)
-        cache_set(key, "1:" + rule.get_expiration)
+        response = get_header(1, rule.get_expiration, rule.limit)
+        cache_set(key, "1:#{rule.get_expiration.to_i}")
       end
     else
-      response = get_header(1, reset = rule.get_expiration, rule.limit)
-      cache_set(key, "1:" + rule.get_expiration)
+      response = get_header(1, rule.get_expiration, rule.limit)
+      cache_set(key, "1:#{rule.get_expiration.to_i}")
     end
     response
   end
 
   def get_header(times, reset, limit)
-    {'x-RateLimit-Limit' => limit.to_s, 'x-RateLimit-Remaining' => (limit - times).to_s, 'x-RateLimit-Reset' => reset.to_s }
+    {'x-RateLimit-Limit' => limit.to_s, 'x-RateLimit-Remaining' => (limit - times).to_s, 'x-RateLimit-Reset' => reset.strftime("%d%m%y%H%M%S") }
   end
 
   def xml_error(code, message)
     "<?xml version=\"1.0\"?>\n<error>\n  <code>#{code}</code>\n  <message>#{message}</message>\n</error>"
   end
-  
+
 end

--- a/lib/rule.rb
+++ b/lib/rule.rb
@@ -1,7 +1,7 @@
 class Rule
 
   def initialize(options)
-    default_options = { 
+    default_options = {
       :match => /.*/,
       :metric => :rph,
       :type => :frequency,
@@ -9,9 +9,9 @@ class Rule
       :per_ip => true,
       :per_url => false,
       :token => false
-    }   
+    }
     @options = default_options.merge(options)
-  
+
   end
 
   def match
@@ -20,11 +20,11 @@ class Rule
 
   def limit
     (@options[:type] == :frequency ? 1 : @options[:limit])
-  end 
+  end
 
   def get_expiration
-    (Time.now + ( @options[:type] == :frequency ? get_frequency : get_fixed )).strftime("%d%m%y%H%M%S")
-  end 
+    (Time.now + ( @options[:type] == :frequency ? get_frequency : get_fixed ))
+  end
 
   def get_frequency
     case @options[:metric]


### PR DESCRIPTION
The current reset logic didn't work at all, as best I could tell. This commit:
- Fixes the reset logic so that multiple request can hit an endpoint, and rate limiting ever can occur
- Uses seconds since epoch as the cache reset format (e.g. Time#to_i)
- Leaves the rate limit header time formatting the same
- Adds support for using ActiveSupport::Cache::Store (Rails.cache) as the cache
- Adds a section in the readme about the storage mechanism
- Adds debug logging for request that match rate limit rules and rate limited requests
